### PR TITLE
Fix debugger for mocha tests @W-4898481@

### DIFF
--- a/templates/sfdxPlugin/tsconfig.json
+++ b/templates/sfdxPlugin/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "./node_modules/@salesforce/dev-config/tsconfig",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDirs": [
-      "./src"
-    ]
+    "rootDir": "./src"
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Since the default plugin we generate only contains one root directory, this seems like a safe change, and it fixes the problem of debugging mocha tests. Existing debugging functionality was not affected and I couldn't find any problems as a result of this change.