### PR TITLE
Correcting OCLIF parameter to show SFDX as the command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 yarn.lock
 package-lock.json
 .idea
+/.history

--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -337,6 +337,7 @@ class App extends Generator {
       this.pjson.oclif = {
         commands: `./${this.ts ? 'lib' : 'src'}/commands`,
         // hooks: {init: `./${this.ts ? 'lib' : 'src'}/hooks/init`},
+        bin: 'sfdx',
         topics: {
           hello: {
             description: 'Commands to say hello.'


### PR DESCRIPTION
Including the oclif attribute to define the "bin" argument. 

When the README.md file is regenerated during the build of a plugin, the README incorrectly shows the plugin's name as the execution command.  It should show the execution command of `sfdx` instead.

This change corrects that issue.

FYI -- @amphro 