### PR TITLE
fix: eslint glob parameters

### DIFF
--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -130,11 +130,11 @@ class App extends Generator {
         node: '>=14.0.0',
       },
       scripts: {
-        posttest: 'eslint src/**/*.ts test/**/*.ts',
+        posttest: 'eslint "src/**/*.ts" "test/**/*.ts"',
         test: 'nyc --extension .ts --require ts-node/register mocha --forbid-only "test/**/*.test.ts"',
         prepack: `${rmrf} lib && tsc -b && oclif manifest && oclif readme`,
         build: 'tsc -p .',
-        lint: 'eslint src/**/*.ts test/**/*.ts',
+        lint: 'eslint "src/**/*.ts" "test/**/*.ts"',
         postpack: `${rmf} oclif.manifest.json`,
         version: 'oclif readme && git add README.md',
       },

--- a/test/src/generators/app.test.ts
+++ b/test/src/generators/app.test.ts
@@ -35,9 +35,9 @@ const expectedPackageJSON = {
   repository: 'johndoe/sfdx-plugin-org',
   scripts: {
     build: 'tsc -p .',
-    lint: 'eslint src/**/*.ts test/**/*.ts',
+    lint: 'eslint "src/**/*.ts" "test/**/*.ts"',
     postpack: `${rmf} oclif.manifest.json`,
-    posttest: 'eslint src/**/*.ts test/**/*.ts',
+    posttest: 'eslint "src/**/*.ts" "test/**/*.ts"',
     prepack: `${rmrf} lib && tsc -b && oclif manifest && oclif readme`,
     test: 'nyc --extension .ts --require ts-node/register mocha --forbid-only "test/**/*.test.ts"',
     version: 'oclif readme && git add README.md',


### PR DESCRIPTION
The glob parameters passed to eslint without double quotes are being expanded by the shell, this can lead to different eslint reports when running on different shells & OS's.

Wrapping the glob parameters in double quotes produces a more predictable output regardless of shell/OS.